### PR TITLE
Move cache to ~/.cache/pronunciation.ogg folder, clean argument match…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This program retrieves pronunciation files from the [dictionary.com]
 (https://www.dictionary.com/) website, which are publicly available
 to be downloaded and plays them automatically.
 This command downloads the pronunciation OGG files via [wget](http://www.gnu.org/software/wget/), stores them
-locally in the **~/pronunciation.ogg** folder, and plays them via [ffplay](http://ffmpeg.org/ffplay.html).
+locally in the **~/.cache/pronunciation.ogg** folder, and plays them via [ffplay](http://ffmpeg.org/ffplay.html).
 
 ##Installation
 
 1. Copy the _pronounce_ script somewhere in your path, for example in
 the **/usr/bin** folder.
-2. Create the **~/pronunciation.ogg** folder.
+2. Create the **~/.cache/pronunciation.ogg** folder.
 3. And install the [ffplay](http://ffmpeg.org/ffplay.html) (usually comes with the _ffmpeg_ package).
 
 ##Usage

--- a/pronounce
+++ b/pronounce
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 PRONOUNCE_VERSION="1.2.0"
+PRONOUNCE_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/pronunciation.ogg"
 
 echo -e "\e[0;32m"
 echo "The pronounce: Frontend for English Words Pronunciation"
@@ -17,7 +18,7 @@ function main {
 	word="$1"
 	number=$2
 	check_cache_folder
-	cd ~/pronunciation.ogg/
+	cd "$PRONOUNCE_CACHE_DIR"
 	if [ -s "${word}-${number}.ogg" ]; then
 		echo "Pronunciation exists locally!";
 	else
@@ -29,8 +30,8 @@ function main {
 }
 
 function check_cache_folder {
-	if [ ! -d ~/pronunciation.ogg ]; then
-		if [ -e ~/pronunciation.ogg ]; then
+	if [ ! -d "$PRONOUNCE_CACHE_DIR" ]; then
+		if [ -e "$PRONOUNCE_CACHE_DIR" ]; then
 			echo -e "\e[0;31m"
 			echo "The pronounce program requires ~/pronunciation.ogg as a cache folder."
 			echo "But that name is already used by a file!"
@@ -38,7 +39,7 @@ function check_cache_folder {
 			echo -e "\e[0m"
 			exit -1
 		fi
-		mkdir ~/pronunciation.ogg
+		mkdir -p "$PRONOUNCE_CACHE_DIR"
 	fi
 }
 
@@ -86,20 +87,18 @@ function print_usage {
 	echo -e "\t-h              Prints this message"
 	echo -e "\e[0m"
 }
-if [ "$1" = "-h" -o "a$1" = "a" ]; then
+if [ -z "$1" -o "$1" = "-h" ]; then
 	print_usage
 elif [ "$1" = "-c" ]; then
 	echo "Purging the cache"
-	rm -f ~/pronunciation.ogg/*
+	rm -f "$PRONOUNCE_CACHE_DIR"/*
 elif [ "$1" = "-v" ]; then
 	echo "Version: $PRONOUNCE_VERSION"
-elif [ "a$2" = "a" ]; then
-	main $1 1
 elif [ "$2" = "f" ]; then
 	run_external_program firefox "https://www.dictionary.com/browse/$1"
 elif [ "$2" = "w" ]; then
 	run_external_program w3m "https://www.dictionary.com/browse/$1"
 else
-	main $1 $2
+	main $1 ${2:-1}
 fi
 

--- a/pronounce
+++ b/pronounce
@@ -46,7 +46,7 @@ function check_cache_folder {
 function get_url {
 	word=$1
 	number=$2
-  url="$(curl https://www.dictionary.com/browse/$word | sed 's!\(<audio[^>]*>\|</audio>\)!\n\1\n!g' | grep '<source' | sed 's|src="\([^"]*\)"|\n\1\n|g' | grep 'https://.*ogg' | tail -n+$number | head -n1)"
+  url="$(curl -L https://www.dictionary.com/browse/$word | sed 's!\(<audio[^>]*>\|</audio>\)!\n\1\n!g' | grep '<source' | sed 's|src="\([^"]*\)"|\n\1\n|g' | grep 'https://.*ogg' | tail -n+$number | head -n1)"
 	echo $url
 }
 


### PR DESCRIPTION
Move the cache to a standard location ~/.cache, this avoids bloating up user's home directory. And cleaned conditionals when checking for empty arguments.